### PR TITLE
build: fully qualify base image names for Podman

### DIFF
--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t consul --rm
 # docker run -ti consul
-FROM alpine:3 AS builder
+FROM docker.io/library/alpine:3 AS builder
 
 ENV CONSUL_VERSION=1.22.3
 
@@ -16,7 +16,7 @@ RUN apk add --no-cache curl unzip && \
     unzip -d /tmp /tmp/consul.zip && \
     rm -f /tmp/consul.zip
 
-FROM alpine:3
+FROM docker.io/library/alpine:3
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="consul" \
       org.opencontainers.image.description="HashiCorp Consul service mesh" \

--- a/esxicompcheck/Dockerfile
+++ b/esxicompcheck/Dockerfile
@@ -1,7 +1,7 @@
 # This is VMware ESXi compatibility checker
 # docker build . -t esxicompcheck --rm
 # docker run -ti esxicompcheck
-FROM almalinux:10 AS builder
+FROM docker.io/library/almalinux:10 AS builder
 WORKDIR /root
 
 RUN dnf -y update && \
@@ -15,7 +15,7 @@ RUN pip3 install --no-cache-dir --prefix=/usr/local pyVim pyvmomi crypto pyopens
     unzip /root/compchecker-v1-20210219.zip && \
     rm -f /root/compchecker-v1-20210219.zip
 
-FROM almalinux:10
+FROM docker.io/library/almalinux:10
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="esxicompcheck" \
       org.opencontainers.image.description="VMware ESXi compatibility checker" \

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -1,7 +1,7 @@
 # This is basic httpd image dockerfile
 # docker build . -t httpd --rm
 # docker run -ti httpd
-FROM almalinux:10
+FROM docker.io/library/almalinux:10
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="httpd" \
       org.opencontainers.image.description="Apache HTTP Server" \

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,7 +1,7 @@
 # This is basic mariadb image dockerfile
 # docker build . -t mariadb --rm
 # docker run -ti mariadb
-FROM almalinux:10
+FROM docker.io/library/almalinux:10
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="mariadb" \
       org.opencontainers.image.description="MariaDB database server" \

--- a/ntp/Dockerfile
+++ b/ntp/Dockerfile
@@ -1,7 +1,7 @@
 # This is ISC NTP container image dockerfile
 # docker build . -t ntp --rm
 # docker run -ti ntp
-FROM almalinux:10
+FROM docker.io/library/almalinux:10
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="ntp" \
       org.opencontainers.image.description="NTP time synchronization daemon using chrony" \

--- a/percona/Dockerfile
+++ b/percona/Dockerfile
@@ -1,7 +1,7 @@
 # This is Percona Server image dockerfile
 # docker build . -t percona --rm
 # docker run -ti percona
-FROM --platform=linux/amd64 debian:bookworm-slim
+FROM --platform=linux/amd64 docker.io/library/debian:bookworm-slim
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="percona" \
       org.opencontainers.image.description="Percona Server for MySQL 8.0" \

--- a/postfix/Dockerfile
+++ b/postfix/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t postfix --rm
 # docker run -ti postfix
-FROM alpine:3
+FROM docker.io/library/alpine:3
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="postfix" \
       org.opencontainers.image.description="Postfix mail transfer agent" \

--- a/powershell/Dockerfile
+++ b/powershell/Dockerfile
@@ -3,7 +3,7 @@
 # docker run -ti powershell
 
 # Stage 1: Install PowerShell and modules
-FROM almalinux:10 AS builder
+FROM docker.io/library/almalinux:10 AS builder
 ARG PS_VERSION=7.5.4
 RUN dnf -y update && \
     dnf install -y curl tar gzip unzip libicu && \
@@ -42,7 +42,7 @@ RUN mkdir -p /root/.local/share/powershell/Modules && \
     rm -f /tmp/ucspowertoolcore.zip
 
 # Stage 2: Minimal runtime
-FROM almalinux:10
+FROM docker.io/library/almalinux:10
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="powershell" \
       org.opencontainers.image.description="PowerShell with VMware, Dell EMC, and AWS modules" \

--- a/snmp/Dockerfile
+++ b/snmp/Dockerfile
@@ -1,7 +1,7 @@
 # This is a SNMP utils dockerfile
 # docker build . -t snmp --rm
 # docker run -ti snmp
-FROM almalinux:10
+FROM docker.io/library/almalinux:10
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="snmp" \
       org.opencontainers.image.description="SNMP network management utilities" \

--- a/uemcli/Dockerfile
+++ b/uemcli/Dockerfile
@@ -4,13 +4,13 @@
 # Note: --platform=linux/amd64 is required because the vendor RPM is x86_64-only
 
 # Stage 1: Extract vendor RPM
-FROM --platform=linux/amd64 almalinux:9 AS builder
+FROM --platform=linux/amd64 docker.io/library/almalinux:9 AS builder
 COPY container-image-root /
 RUN rpm -ivh UnisphereCLI-Linux-64-x86-en_US-4.2.1.1.2069-1.x86_64.rpm && \
     /opt/emc/uemcli/bin/setlevel.sh low
 
 # Stage 2: Minimal runtime
-FROM --platform=linux/amd64 almalinux:9
+FROM --platform=linux/amd64 docker.io/library/almalinux:9
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="uemcli" \
       org.opencontainers.image.description="Dell EMC Unity CLI management tools" \

--- a/vnxcli/Dockerfile
+++ b/vnxcli/Dockerfile
@@ -4,14 +4,14 @@
 # Note: --platform=linux/amd64 is required because the vendor RPM is x86_64-only
 
 # Stage 1: Extract vendor RPM
-FROM --platform=linux/amd64 almalinux:9 AS builder
+FROM --platform=linux/amd64 docker.io/library/almalinux:9 AS builder
 COPY container-image-root /
 RUN dnf install -y libnsl && dnf clean all && rm -rf /var/cache/dnf
 RUN rpm -ivh NaviCLI-Linux-64-x86-en_US-7.33.9.1.84-1.x86_64.rpm && \
     /setlevel.sh
 
 # Stage 2: Minimal runtime
-FROM --platform=linux/amd64 almalinux:9
+FROM --platform=linux/amd64 docker.io/library/almalinux:9
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="vnxcli" \
       org.opencontainers.image.description="Dell EMC VNX CLI management tools" \

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,7 +1,7 @@
 # This is basic wordpress image dockerfile
 # docker build . -t wordpress --rm
 # docker run -ti wordpress
-FROM almalinux:10 AS builder
+FROM docker.io/library/almalinux:10 AS builder
 
 RUN dnf -y update && \
     dnf -y install curl tar gzip && \
@@ -12,7 +12,7 @@ RUN curl -LO https://wordpress.org/latest.tar.gz && \
     tar xzf /latest.tar.gz -C /tmp && \
     rm -f /latest.tar.gz
 
-FROM almalinux:10
+FROM docker.io/library/almalinux:10
 LABEL maintainer="Frederic Jacquet <fred@ljf.ch>" \
       org.opencontainers.image.title="wordpress" \
       org.opencontainers.image.description="WordPress CMS with Apache and PHP" \


### PR DESCRIPTION
Preparation for the Docker→Podman move.

Podman resolves unqualified image names via `unqualified-search-registries` in `registries.conf`. On RHEL/Fedora that list does not start with `docker.io`, and under `short-name-mode="enforcing"` an unqualified name fails outright in a non-interactive build. Docker always implies `docker.io/library`.

Every base image is now fully qualified. Already-qualified refs (`ghcr.io/*`, `gcr.io/*`, `registry.access.redhat.com/*`), `FROM scratch`, and inter-stage `FROM <stage>` references are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container builds to use fully qualified Docker Hub image references.
  * Standardized base image resolution across Alpine, AlmaLinux, and Debian-based builds.
  * Preserved existing build stages, runtime behavior, and image versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->